### PR TITLE
Don't regard as `Using index` if using ICP

### DIFF
--- a/lib/explain_parser.rb
+++ b/lib/explain_parser.rb
@@ -43,7 +43,7 @@ class ExplainParser
     end
 
     def using_index?
-      !!(extra =~ /Using index/)
+      !!(extra =~ /Using index(?! condition)/)
     end
   end
 

--- a/spec/lib/explain_parser_spec.rb
+++ b/spec/lib/explain_parser_spec.rb
@@ -113,4 +113,25 @@ describe ExplainParser do
       end
     end
   end
+
+  context 'given explain string that using ICP' do
+    let(:input) do
+      <<-EOS
++----+-------------+-------+-------+------------------------+
+| id | select_type | table | type  | Extra                  |
++----+-------------+-------+-------+------------------------+
+|  1 | SIMPLE      | tc    | range | Using index condition  |
++----+-------------+-------+-------+------------------------+
+1 row in set (0.00 sec)
+    EOS
+    end
+
+    describe 'Explain#using_index?' do
+      subject do
+        explain = ExplainParser.call(input)[0]
+        explain.using_index?
+      end
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
If using ICP, appear `Using index condition` in Extra field. It's similar value to `Using index`, however their meaning aren't the same.